### PR TITLE
[ODBC] Access violation when working with blobs

### DIFF
--- a/src/component/ZAbstractDataset.pas
+++ b/src/component/ZAbstractDataset.pas
@@ -913,7 +913,7 @@ var
             try
               DestStream := DestDataset.CreateBlobStream(DestField, bmWrite);
               try
-                DestStream.Size := 0; // need to Realloc and set FUpdated = true
+                DestStream.Size := 0; // need to Realloc and set FUpdated = true when DestStream.Size >= SrcStream.Size 
                 DestStream.CopyFrom(SrcStream, 0);
               finally
                 DestStream.Free;

--- a/src/component/ZAbstractDataset.pas
+++ b/src/component/ZAbstractDataset.pas
@@ -913,6 +913,7 @@ var
             try
               DestStream := DestDataset.CreateBlobStream(DestField, bmWrite);
               try
+                DestStream.Size := 0; // need to Realloc and set FUpdated = true
                 DestStream.CopyFrom(SrcStream, 0);
               finally
                 DestStream.Free;

--- a/src/dbc/ZDbcODBCResultSet.pas
+++ b/src/dbc/ZDbcODBCResultSet.pas
@@ -1669,6 +1669,7 @@ procedure TAbstractODBCResultSet.LoadUnBoundColumns;
 var
   ColumnIndex: Integer;
   StrLen_or_IndPtr: PSQLLEN;
+  ZeroBuffer : Byte;  
 begin
   for ColumnIndex := fFirstGetDataIndex to fLastGetDataIndex do
     with TZODBCColumnInfo(ColumnsInfo[ColumnIndex]) do begin
@@ -1682,7 +1683,7 @@ begin
         else begin
           { check out length of lob }
           CheckStmtError(fPlainDriver.SQLGetData(fPHSTMT^, ColumnIndex+1,
-            ODBC_CType, Pointer(1){can not be nil}, 0, StrLen_or_IndPtr));
+            ODBC_CType, @ZeroBuffer, 0, StrLen_or_IndPtr));
           if StrLen_or_IndPtr^ = SQL_NULL_DATA then
             PIZlob(@ColumnBuffer)^ := nil
           else if ColumnType = stBinaryStream


### PR DESCRIPTION
Hi

In some cases this code in TAbstractODBCResultSet.LoadUnBoundColumns cause access violation:

`Project XXX raised exception class EAccessViolation with message 'Access violation at address 10051AF9 in module 'OdbcFb.dll'. Write of address 00000001'.`

Problem in:

```
CheckStmtError(fPlainDriver.SQLGetData(fPHSTMT^, ColumnIndex+1,
            ODBC_CType, Pointer(1){can not be nil}, 0, StrLen_or_IndPtr));
```

Need to be changed to:

```
  ZeroBuffer : Byte;  
...
CheckStmtError(fPlainDriver.SQLGetData(fPHSTMT^, ColumnIndex+1,
            ODBC_CType, @ZeroBuffer, 0, StrLen_or_IndPtr));
```